### PR TITLE
Adds dot extension to proof against pathing that may contain 'po'.

### DIFF
--- a/src/laravel-mix-po2mo.js
+++ b/src/laravel-mix-po2mo.js
@@ -80,7 +80,7 @@ class Po2Mo {
                 cwd: theme.langPath,
             } ).forEach( file => {
                 file = path.join( theme.langPath, file );
-                sh.exec( 'msgfmt -o ' + file.replace( 'po', 'mo' ) + ' ' + file );
+                sh.exec( 'msgfmt -o ' + file.replace( '.po', '.mo' ) + ' ' + file );
                 sh.echo( file );
             } );
         } );


### PR DESCRIPTION
This is to fix pathing that may contain "po" which it would try to change to "mo", such as:

`msgfmt: error while opening "/Users/seanmotts/devel/...`